### PR TITLE
Rest add metrics api

### DIFF
--- a/jersey/jersey-hello-world/README.md
+++ b/jersey/jersey-hello-world/README.md
@@ -12,3 +12,8 @@ https://mkyong.com/webservices/jax-rs/jersey-hello-world-example/
 2. ETL
 3. 上报采集
 
+
+# 成果
+借助大模型 + 文档实现了filter metrics 的归一化处理
+
+AccessLogFilter:normalizePath()

--- a/jersey/jersey-hello-world/README.md
+++ b/jersey/jersey-hello-world/README.md
@@ -1,3 +1,14 @@
 # Jersey hello world example
 
 https://mkyong.com/webservices/jax-rs/jersey-hello-world-example/
+
+
+
+
+## 改造
+基于Jersey-hello-world-example实现埋点开发
+0. 骨架
+1. 埋点
+2. ETL
+3. 上报采集
+

--- a/jersey/jersey-hello-world/pom.xml
+++ b/jersey/jersey-hello-world/pom.xml
@@ -74,6 +74,66 @@
             <scope>test</scope>
         </dependency>
 
+
+
+        <!--增加监控相关的jar-->
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-annotation</artifactId>
+            <version>4.2.4</version>
+        </dependency>
+
+<!--        <dependency>-->
+<!--            <groupId>org.apache.hugegraph</groupId>-->
+<!--            <artifactId>hugegraph-common</artifactId>-->
+<!--            <version>1.3.0</version>-->
+<!--        </dependency>-->
+
+        <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-shaded</artifactId>
+            <version>3.5.1</version>
+        </dependency>
+
+
+
+        <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-server</artifactId>
+            <version>3.5.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.0.1-android</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jersey3</artifactId>
+            <version>4.2.4</version>
+        </dependency>
+
+<!--        <dependency>-->
+<!--            <groupId>io.dropwizard.metrics</groupId>-->
+<!--            <artifactId>metrics-core</artifactId>-->
+<!--            <version>4.2.26</version>-->
+<!--        </dependency>-->
+
+        <dependency>
+            <groupId>com.codahale.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/MainApp.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/MainApp.java
@@ -1,12 +1,20 @@
 package com.mkyong;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jersey3.InstrumentedResourceMethodApplicationListener;
 import com.mkyong.config.AutoScanFeature;
+import com.mkyong.filter.AccessLogFilter;
+import com.mkyong.metrics.ServerReporter;
+import com.mkyong.resource.MetricsAPI;
 import com.mkyong.resource.MyResource;
+import com.mkyong.resource.PathParamAPI;
+import org.apache.tinkerpop.gremlin.server.util.MetricManager;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
 
 import java.net.URI;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -15,18 +23,30 @@ public class MainApp {
     private static final Logger LOGGER = Logger.getLogger(MainApp.class.getName());
 
     // we start at port 8080
-    public static final String BASE_URI = "http://localhost:8080/";
+    public static final String BASE_URI = "http://localhost:8081/";
 
     // Starts Grizzly HTTP server
     public static HttpServer startServer() {
+        final MetricManager metric = MetricManager.INSTANCE;
+        // Force to add server reporter
+        ServerReporter reporter = ServerReporter.instance(metric.getRegistry());
+        reporter.start(60L, TimeUnit.SECONDS);
 
         // scan packages
         final ResourceConfig config = new ResourceConfig();
-        // config.packages(true, "com.mkyong");
-        config.register(MyResource.class);
+        config.packages("com.mkyong");//这一行代码的作用是扫描并注册指定包中的所有JAX-RS资源和提供者（如过滤器、拦截器等）
+//        config.register(MyResource.class);
+//        config.register(MetricsAPI.class);
+//        config.register(PathParamAPI.class);
+        //config.register(AccessLogFilter.class);
+        //config.register(new AccessLogFilter());
 
         // enable auto scan @Contract and @Service
         config.register(AutoScanFeature.class);
+        // Let @Metric annotations work
+        MetricRegistry registry = metric.getRegistry();
+        config.register(new InstrumentedResourceMethodApplicationListener(registry));
+        //config.register(registry);
 
         LOGGER.info("Starting Server........");
 
@@ -40,6 +60,7 @@ public class MainApp {
     public static void main(String[] args) {
 
         try {
+
 
             final HttpServer httpServer = startServer();
 

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/filter/AccessLogFilter.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/filter/AccessLogFilter.java
@@ -4,7 +4,7 @@ package com.mkyong.filter;
 import com.mkyong.metrics.MetricsUtil;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.HttpMethod;
-import jakarta.ws.rs.Path;
+
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
@@ -14,7 +14,7 @@ import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.Provider;
 import org.apache.tinkerpop.gremlin.server.GraphManager;
 
-import java.lang.reflect.Method;
+
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/filter/AccessLogFilter.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/filter/AccessLogFilter.java
@@ -1,0 +1,191 @@
+package com.mkyong.filter;
+
+
+import com.mkyong.metrics.MetricsUtil;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.Provider;
+import org.apache.tinkerpop.gremlin.server.GraphManager;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static com.mkyong.metrics.MetricsUtil.*;
+
+@Provider
+@Singleton
+public class AccessLogFilter implements ContainerResponseFilter {
+    private static final String DELIMITER = "/";
+    private static final String GRAPHS = "graphs";
+    private static final String GREMLIN = "gremlin";
+    private static final String CYPHER = "cypher";
+
+
+    private static final Pattern ID_PATTERN = Pattern.compile("\"\\d+:\\w+\"");
+    private static final Pattern QUOTED_STRING_PATTERN = Pattern.compile("\"\\w+\"");
+    public static final String REQUEST_TIME = "request_time";
+
+    //TODO: 此处实现定制话的filter
+
+//    @Context
+//    private jakarta.inject.Provider<HugeConfig> configProvider;
+
+    @Context
+    private jakarta.inject.Provider<GraphManager> managerProvider;
+
+
+    public static boolean needRecordLog(ContainerRequestContext context) {
+        // TODO: add test for 'path' result ('/gremlin' or 'gremlin')
+        String path = context.getUriInfo().getPath();
+
+        // GraphsAPI/CypherAPI/Job GremlinAPI
+        if (path.startsWith(GRAPHS)) {
+            if (HttpMethod.GET.equals(context.getMethod()) || path.endsWith(CYPHER)) {
+                return true;
+            }
+        }
+        // Direct GremlinAPI
+        return path.endsWith(GREMLIN);
+    }
+
+    private String join(String path1, String path2) {
+        return String.join(DELIMITER, path1, path2);
+    }
+
+    private String normalizePath(ContainerRequestContext requestContext) {
+        // Replace variable parts of the path with placeholders
+        //TODO: 判断此方法参数是在路径上的
+        /**
+         * 核心逻辑
+         * 1. 判断此路径是否含有参数
+         * 2. 如果是，则归一化处理
+         * 3. 如果不是,则不处理，直接返回路径
+         */
+
+        String requestPath = requestContext.getUriInfo().getPath();
+        // 获取路径参数的值
+        MultivaluedMap<String, String> pathParameters = requestContext.getUriInfo().getPathParameters();
+        // 替换路径
+        //String newPath = requestPath.replace(name, "name").replace(graph, "graph");
+
+        String newPath = requestPath;
+        for (Map.Entry<String, java.util.List<String>> entry : pathParameters.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue().get(0); // 获取第一个值
+            newPath = newPath.replace(value, key);
+        }
+
+
+
+
+        System.out.println("Original Path: " + requestPath);
+        System.out.println("New Path: " + newPath);
+        return newPath;
+    }
+
+
+    /**
+     * 核心逻辑
+     * 1. 拦截后 计算N个指标
+     *  成功
+     *  失败
+     *  慢查询
+     *
+     *  此处暴露的问题：
+     *  指标注册过程中 出现 OOM
+     */
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+
+        //没枚举requestContext 能获取的所有信息
+        UriInfo info  = requestContext.getUriInfo();
+        List<String> PathList = info.getMatchedURIs();
+
+
+
+
+        // Grab corresponding request / response info from context;
+        String method = requestContext.getMethod();
+        String path =  normalizePath(requestContext);
+
+
+
+        // 使用 pathTemplate 作为 metrics key
+        String metricsKey = path;
+
+        System.out.println("metricsKey: " + metricsKey);
+
+        String metricsName = join(metricsKey, method);
+
+        MetricsUtil.registerCounter(join(metricsName, METRICS_PATH_TOTAL_COUNTER)).inc();
+        if (statusOk(responseContext.getStatus())) {
+            MetricsUtil.registerCounter(join(metricsName, METRICS_PATH_SUCCESS_COUNTER)).inc();
+        } else {
+            MetricsUtil.registerCounter(join(metricsName, METRICS_PATH_FAILED_COUNTER)).inc();
+        }
+
+        Object requestTime = requestContext.getProperty(REQUEST_TIME);
+        if (requestTime != null) {
+            long now = System.currentTimeMillis();
+            long start = (Long) requestTime;
+            long executeTime = now - start;
+
+            MetricsUtil.registerHistogram(join(metricsName, METRICS_PATH_RESPONSE_TIME_HISTOGRAM))
+                       .update(executeTime);
+
+            long timeThreshold = 3000;
+            // Record slow query if meet needs, watch out the perf
+            if (timeThreshold > 0 && executeTime > timeThreshold &&
+                needRecordLog(requestContext)) {
+                // TODO: set RequestBody null, handle it later & should record "client IP"
+//                LOG.info("[Slow Query] execTime={}ms, body={}, method={}, path={}, query={}",
+//                         executeTime, null, method, path, uri.getQuery());
+            }
+        }
+
+    }
+
+//    private String extractMethodPath(ContainerRequestContext requestContext) {
+//        // 使用 UriInfo 获取路径模板
+//        UriInfo uriInfo = requestContext.getUriInfo();
+//        List<Object> matchedResources = uriInfo.getMatchedResources();
+//        if (matchedResources.isEmpty()) {
+//            return "";
+//        }
+//        Object resource = matchedResources.get(0);
+//        String requestPath = requestContext.getUriInfo().getPath();
+//        for (Method method : resource.getClass().getDeclaredMethods()) {
+//            Path methodPath = method.getAnnotation(Path.class);
+//            if (methodPath != null && requestPath.endsWith(methodPath.value())) {
+//                return "/"+methodPath.value();
+//            }
+//        }
+//        return "";
+//    }
+//
+//    private String extractPathTemplate(ContainerRequestContext requestContext) {
+//        // 使用 UriInfo 获取路径模板
+//        UriInfo uriinfo = requestContext.getUriInfo();
+//        List<Object> matchedResources = uriinfo.getMatchedResources();//什么时候为空，什么时候不为空
+//        if (matchedResources.isEmpty()) {
+//            return requestContext.getUriInfo().getPath();
+//        }
+//        Object resource = matchedResources.get(0);
+//        Path classPath = resource.getClass().getAnnotation(Path.class);
+//        String classPathValue = classPath != null ? classPath.value() : "";
+//        return classPathValue ;
+//    }
+
+    private boolean statusOk(int status) {
+        return status >= 200 && status < 300;
+    }
+}

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/metrics/MetricsKeys.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/metrics/MetricsKeys.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mkyong.metrics;
+
+public enum MetricsKeys {
+
+    MAX_RESPONSE_TIME(1, "max_response_time"),
+
+    MEAN_RESPONSE_TIME(2, "mean_response_time"),
+
+    TOTAL_REQUEST(3, "total_request"),
+
+    FAILED_REQUEST(4, "failed_request"),
+
+    SUCCESS_REQUEST(5, "success_request");
+
+    private final byte code;
+    private final String name;
+
+    MetricsKeys(int code, String name) {
+        assert code < 256;
+        this.code = (byte) code;
+        this.name = name;
+    }
+}

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/metrics/MetricsModule.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/metrics/MetricsModule.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mkyong.metrics;
+
+import com.codahale.metrics.*;
+import org.apache.tinkerpop.shaded.jackson.core.JsonGenerator;
+import org.apache.tinkerpop.shaded.jackson.core.Version;
+import org.apache.tinkerpop.shaded.jackson.databind.Module;
+import org.apache.tinkerpop.shaded.jackson.databind.SerializerProvider;
+import org.apache.tinkerpop.shaded.jackson.databind.module.SimpleSerializers;
+import org.apache.tinkerpop.shaded.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Copy from com.codahale.metrics.json.MetricsModule
+ */
+public class MetricsModule extends Module {
+
+    private static final Version VERSION = new Version(1, 1, 0, "",
+                                                       "org.apache.hugegraph",
+                                                       "hugegraph-api");
+
+    @SuppressWarnings("rawtypes")
+    private static class GaugeSerializer extends StdSerializer<Gauge> {
+
+        private static final long serialVersionUID = -5347786455542725809L;
+
+        private GaugeSerializer() {
+            super(Gauge.class);
+        }
+
+        @Override
+        public void serialize(Gauge gauge, JsonGenerator json,
+                              SerializerProvider provider) throws IOException {
+            json.writeStartObject();
+            final Object value;
+            try {
+                value = gauge.getValue();
+                json.writeObjectField("value", value);
+            } catch (RuntimeException e) {
+                json.writeObjectField("error", e.toString());
+            }
+            json.writeEndObject();
+        }
+    }
+
+    private static class CounterSerializer extends StdSerializer<Counter> {
+
+        private static final long serialVersionUID = -209508117719806468L;
+
+        private CounterSerializer() {
+            super(Counter.class);
+        }
+
+        @Override
+        public void serialize(Counter counter, JsonGenerator json,
+                              SerializerProvider provider) throws IOException {
+            json.writeStartObject();
+            json.writeNumberField("count", counter.getCount());
+            json.writeEndObject();
+        }
+    }
+
+    private static class HistogramSerializer extends StdSerializer<Histogram> {
+
+        private static final long serialVersionUID = -775852382644934747L;
+
+        private final boolean showSamples;
+
+        private HistogramSerializer(boolean showSamples) {
+            super(Histogram.class);
+            this.showSamples = showSamples;
+        }
+
+        @Override
+        public void serialize(Histogram histogram, JsonGenerator json,
+                              SerializerProvider provider) throws IOException {
+            json.writeStartObject();
+            final Snapshot snapshot = histogram.getSnapshot();
+            json.writeNumberField("count", histogram.getCount());
+            json.writeNumberField("min", snapshot.getMin());
+            json.writeNumberField("mean", snapshot.getMean());
+            json.writeNumberField("max", snapshot.getMax());
+            json.writeNumberField("stddev", snapshot.getStdDev());
+            json.writeNumberField("p50", snapshot.getMedian());
+            json.writeNumberField("p75", snapshot.get75thPercentile());
+            json.writeNumberField("p95", snapshot.get95thPercentile());
+            json.writeNumberField("p98", snapshot.get98thPercentile());
+            json.writeNumberField("p99", snapshot.get99thPercentile());
+            json.writeNumberField("p999", snapshot.get999thPercentile());
+
+            if (this.showSamples) {
+                json.writeObjectField("values", snapshot.getValues());
+            }
+
+            json.writeEndObject();
+        }
+    }
+
+    private static class MeterSerializer extends StdSerializer<Meter> {
+
+        private static final long serialVersionUID = 5418467941358294770L;
+
+        private final String rateUnit;
+        private final double rateFactor;
+
+        public MeterSerializer(TimeUnit rateUnit) {
+            super(Meter.class);
+            this.rateFactor = rateUnit.toSeconds(1);
+            this.rateUnit = calculateRateUnit(rateUnit, "events");
+        }
+
+        @Override
+        public void serialize(Meter meter, JsonGenerator json,
+                              SerializerProvider provider) throws IOException {
+            json.writeStartObject();
+            json.writeNumberField("count", meter.getCount());
+            json.writeNumberField("mean_rate", meter.getMeanRate() *
+                                               this.rateFactor);
+            json.writeNumberField("m15_rate", meter.getFifteenMinuteRate() *
+                                              this.rateFactor);
+            json.writeNumberField("m5_rate", meter.getFiveMinuteRate() *
+                                             this.rateFactor);
+            json.writeNumberField("m1_rate", meter.getOneMinuteRate() *
+                                             this.rateFactor);
+            json.writeStringField("rate_unit", this.rateUnit);
+            json.writeEndObject();
+        }
+    }
+
+    private static class TimerSerializer extends StdSerializer<Timer> {
+
+        private static final long serialVersionUID = 6283520188524929099L;
+
+        private final String rateUnit;
+        private final double rateFactor;
+        private final String durationUnit;
+        private final double durationFactor;
+        private final boolean showSamples;
+
+        private TimerSerializer(TimeUnit rateUnit, TimeUnit durationUnit,
+                                boolean showSamples) {
+            super(Timer.class);
+            this.rateUnit = calculateRateUnit(rateUnit, "calls");
+            this.rateFactor = rateUnit.toSeconds(1);
+            this.durationUnit = durationUnit.toString().toLowerCase(Locale.US);
+            this.durationFactor = 1.0 / durationUnit.toNanos(1);
+            this.showSamples = showSamples;
+        }
+
+        @Override
+        public void serialize(Timer timer, JsonGenerator json,
+                              SerializerProvider provider) throws IOException {
+            json.writeStartObject();
+            final Snapshot snapshot = timer.getSnapshot();
+            json.writeNumberField("count", timer.getCount());
+            json.writeNumberField("min", snapshot.getMin() *
+                                         this.durationFactor);
+            json.writeNumberField("mean", snapshot.getMean() *
+                                          this.durationFactor);
+            json.writeNumberField("max", snapshot.getMax() *
+                                         this.durationFactor);
+            json.writeNumberField("stddev", snapshot.getStdDev() *
+                                            this.durationFactor);
+
+            json.writeNumberField("p50", snapshot.getMedian() *
+                                         this.durationFactor);
+            json.writeNumberField("p75", snapshot.get75thPercentile() *
+                                         this.durationFactor);
+            json.writeNumberField("p95", snapshot.get95thPercentile() *
+                                         this.durationFactor);
+            json.writeNumberField("p98", snapshot.get98thPercentile() *
+                                         this.durationFactor);
+            json.writeNumberField("p99", snapshot.get99thPercentile() *
+                                         this.durationFactor);
+            json.writeNumberField("p999", snapshot.get999thPercentile() *
+                                          this.durationFactor);
+            json.writeStringField("duration_unit", this.durationUnit);
+
+            if (this.showSamples) {
+                final long[] values = snapshot.getValues();
+                final double[] scaledValues = new double[values.length];
+                for (int i = 0; i < values.length; i++) {
+                    scaledValues[i] = values[i] * this.durationFactor;
+                }
+                json.writeObjectField("values", scaledValues);
+            }
+
+            json.writeNumberField("mean_rate", timer.getMeanRate() *
+                                               this.rateFactor);
+            json.writeNumberField("m15_rate", timer.getFifteenMinuteRate() *
+                                              this.rateFactor);
+            json.writeNumberField("m5_rate", timer.getFiveMinuteRate() *
+                                             this.rateFactor);
+            json.writeNumberField("m1_rate", timer.getOneMinuteRate() *
+                                             this.rateFactor);
+            json.writeStringField("rate_unit", this.rateUnit);
+            json.writeEndObject();
+        }
+    }
+
+    private static class MetricRegistrySerializer
+            extends StdSerializer<MetricRegistry> {
+
+        private static final long serialVersionUID = 3717001164181726933L;
+
+        private final MetricFilter filter;
+
+        private MetricRegistrySerializer(MetricFilter filter) {
+            super(MetricRegistry.class);
+            this.filter = filter;
+        }
+
+        @Override
+        public void serialize(MetricRegistry registry, JsonGenerator json,
+                              SerializerProvider provider) throws IOException {
+            json.writeStartObject();
+            json.writeStringField("version", VERSION.toString());
+            json.writeObjectField("gauges", registry.getGauges(this.filter));
+            json.writeObjectField("counters",
+                                  registry.getCounters(this.filter));
+            json.writeObjectField("histograms",
+                                  registry.getHistograms(this.filter));
+            json.writeObjectField("meters", registry.getMeters(this.filter));
+            json.writeObjectField("timers", registry.getTimers(this.filter));
+            json.writeEndObject();
+        }
+    }
+
+    private final TimeUnit rateUnit;
+    private final TimeUnit durationUnit;
+    private final boolean showSamples;
+    private final MetricFilter filter;
+
+    public MetricsModule(TimeUnit rateUnit, TimeUnit durationUnit,
+                         boolean showSamples) {
+        this(rateUnit, durationUnit, showSamples, MetricFilter.ALL);
+    }
+
+    public MetricsModule(TimeUnit rateUnit, TimeUnit durationUnit,
+                         boolean showSamples, MetricFilter filter) {
+        this.rateUnit = rateUnit;
+        this.durationUnit = durationUnit;
+        this.showSamples = showSamples;
+        this.filter = filter;
+    }
+
+    @Override
+    public String getModuleName() {
+        return "metrics";
+    }
+
+    @Override
+    public Version version() {
+        return VERSION;
+    }
+
+    @Override
+    public void setupModule(Module.SetupContext context) {
+        context.addSerializers(new SimpleSerializers(Arrays.asList(
+                new GaugeSerializer(),
+                new CounterSerializer(),
+                new HistogramSerializer(this.showSamples),
+                new MeterSerializer(this.rateUnit),
+                new TimerSerializer(this.rateUnit, this.durationUnit,
+                                    this.showSamples),
+                new MetricRegistrySerializer(this.filter)
+        )));
+    }
+
+    private static String calculateRateUnit(TimeUnit unit, String name) {
+        final String s = unit.toString().toLowerCase(Locale.US);
+        return name + '/' + s.substring(0, s.length() - 1);
+    }
+}

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/metrics/MetricsUtil.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/metrics/MetricsUtil.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mkyong.metrics;
+
+import com.codahale.metrics.*;
+import org.apache.tinkerpop.gremlin.server.util.MetricManager;
+
+public class MetricsUtil {
+
+    public static final String METRICS_PATH_TOTAL_COUNTER = "TOTAL_COUNTER";
+    public static final String METRICS_PATH_FAILED_COUNTER = "FAILED_COUNTER";
+    public static final String METRICS_PATH_SUCCESS_COUNTER = "SUCCESS_COUNTER";
+    public static final String METRICS_PATH_RESPONSE_TIME_HISTOGRAM =
+            "RESPONSE_TIME_HISTOGRAM";
+    public static final String P75_ATTR = "{name=\"p75\",} ";
+    public static final String P95_ATTR = "{name=\"p95\",} ";
+    public static final String P98_ATTR = "{name=\"p98\",} ";
+    public static final String P99_ATTR = "{name=\"p99\",} ";
+    public static final String P999_ATTR = "{name=\"p999\",} ";
+    public static final String MEAN_RATE_ATRR = "{name=\"mean_rate\",} ";
+    public static final String ONE_MIN_RATE_ATRR = "{name=\"m1_rate\",} ";
+    public static final String FIVE_MIN_RATE_ATRR = "{name=\"m5_rate\",} ";
+    public static final String FIFT_MIN_RATE_ATRR = "{name=\"m15_rate\",} ";
+    public static final MetricRegistry REGISTRY = MetricManager.INSTANCE.getRegistry();
+    public static final String STR_HELP = "# HELP ";
+    public static final String STR_TYPE = "# TYPE ";
+    public static final String HISTOGRAM_TYPE = "histogram";
+    public static final String UNTYPED = "untyped";
+    public static final String GAUGE_TYPE = "gauge";
+    public static final String END_LSTR = "\n";
+    public static final String SPACE_STR = " ";
+    public static final String VERSION_STR = "{version=\"";
+    public static final String COUNT_ATTR = "{name=\"count\",} ";
+    public static final String MIN_ATTR = "{name=\"min\",} ";
+    public static final String MAX_ATTR = "{name=\"max\",} ";
+    public static final String MEAN_ATTR = "{name=\"mean\",} ";
+    public static final String STDDEV_ATTR = "{name=\"stddev\",} ";
+    public static final String P50_ATTR = "{name=\"p50\",} ";
+
+    public static final String LEFT_NAME_STR = "{name=";
+    public static final String RIGHT_NAME_STR = ",} ";
+    public static final String PROM_HELP_NAME = "hugegraph_info";
+
+    public static <T> Gauge<T> registerGauge(Class<?> clazz, String name,
+                                             Gauge<T> gauge) {
+        return REGISTRY.register(MetricRegistry.name(clazz, name), gauge);
+    }
+
+    public static Counter registerCounter(Class<?> clazz, String name) {
+        return REGISTRY.counter(MetricRegistry.name(clazz, name));
+    }
+
+    public static Counter registerCounter(String name) {
+        return REGISTRY.counter(MetricRegistry.name(name));
+    }
+
+    public static Histogram registerHistogram(Class<?> clazz, String name) {
+        return REGISTRY.histogram(MetricRegistry.name(clazz, name));
+    }
+
+    public static Histogram registerHistogram(String name) {
+        return REGISTRY.histogram(name);
+    }
+
+    public static Meter registerMeter(Class<?> clazz, String name) {
+        return REGISTRY.meter(MetricRegistry.name(clazz, name));
+    }
+
+    public static Timer registerTimer(Class<?> clazz, String name) {
+        return REGISTRY.timer(MetricRegistry.name(clazz, name));
+    }
+
+    public static String replaceDotDashInKey(String orgKey) {
+        return orgKey.replace(".", "_").replace("-", "_").replace("/", "_").replace("$", "_");
+    }
+
+    public static String replaceSlashInKey(String orgKey) {
+        return orgKey.replace("/", "_");
+    }
+
+    public static void writePrometheusFormat(StringBuilder promeMetrics, MetricRegistry registry) {
+        // gauges
+        registry.getGauges().forEach((key, gauge) -> {
+            if (gauge != null) {
+                String helpName = replaceDotDashInKey(key);
+                promeMetrics.append(STR_HELP)
+                            .append(helpName).append(END_LSTR);
+                promeMetrics.append(STR_TYPE)
+                            .append(helpName).append(SPACE_STR + GAUGE_TYPE + END_LSTR);
+                promeMetrics.append(helpName).append(SPACE_STR).append(gauge.getValue())
+                            .append(END_LSTR);
+            }
+        });
+
+        // histograms
+        registry.getHistograms().forEach((key, histogram) -> {
+            if (histogram != null) {
+                String helpName = replaceDotDashInKey(key);
+                promeMetrics.append(STR_HELP)
+                            .append(helpName).append(END_LSTR);
+                promeMetrics.append(STR_TYPE)
+                            .append(helpName)
+                            .append(SPACE_STR + HISTOGRAM_TYPE + END_LSTR);
+
+                promeMetrics.append(helpName)
+                            .append(COUNT_ATTR).append(histogram.getCount()).append(END_LSTR);
+                promeMetrics.append(
+                        exportSnapshot(helpName, histogram.getSnapshot()));
+            }
+        });
+
+        // meters
+        registry.getMeters().forEach((key, metric) -> {
+            if (metric != null) {
+                String helpName = replaceDotDashInKey(key);
+                promeMetrics.append(STR_HELP)
+                            .append(helpName).append(END_LSTR);
+                promeMetrics.append(STR_TYPE)
+                            .append(helpName)
+                            .append(SPACE_STR + HISTOGRAM_TYPE + END_LSTR);
+
+                promeMetrics.append(helpName)
+                            .append(COUNT_ATTR).append(metric.getCount()).append(END_LSTR);
+                promeMetrics.append(helpName)
+                            .append(MEAN_RATE_ATRR).append(metric.getMeanRate()).append(END_LSTR);
+                promeMetrics.append(helpName)
+                            .append(ONE_MIN_RATE_ATRR).append(metric.getOneMinuteRate())
+                            .append(END_LSTR);
+                promeMetrics.append(helpName)
+                            .append(FIVE_MIN_RATE_ATRR).append(metric.getFiveMinuteRate())
+                            .append(END_LSTR);
+                promeMetrics.append(helpName)
+                            .append(FIFT_MIN_RATE_ATRR).append(metric.getFifteenMinuteRate())
+                            .append(END_LSTR);
+            }
+        });
+
+        // timer
+        registry.getTimers().forEach((key, timer) -> {
+            if (timer != null) {
+                String helpName = replaceDotDashInKey(key);
+                promeMetrics.append(STR_HELP)
+                            .append(helpName).append(END_LSTR);
+                promeMetrics.append(STR_TYPE)
+                            .append(helpName)
+                            .append(SPACE_STR + HISTOGRAM_TYPE + END_LSTR);
+
+                promeMetrics.append(helpName)
+                            .append(COUNT_ATTR).append(timer.getCount()).append(END_LSTR);
+                promeMetrics.append(helpName)
+                            .append(ONE_MIN_RATE_ATRR).append(timer.getOneMinuteRate())
+                            .append(END_LSTR);
+                promeMetrics.append(helpName)
+                            .append(FIVE_MIN_RATE_ATRR).append(timer.getFiveMinuteRate())
+                            .append(END_LSTR);
+                promeMetrics.append(helpName)
+                            .append(FIFT_MIN_RATE_ATRR).append(timer.getFifteenMinuteRate())
+                            .append(END_LSTR);
+                promeMetrics.append(
+                        exportSnapshot(helpName, timer.getSnapshot()));
+            }
+        });
+    }
+
+    public static String exportSnapshot(final String helpName, final Snapshot snapshot) {
+        if (snapshot == null) {
+            return "";
+        }
+        StringBuilder snapMetrics = new StringBuilder();
+        snapMetrics.append(helpName)
+                   .append(MIN_ATTR).append(snapshot.getMin()).append(END_LSTR);
+        snapMetrics.append(helpName)
+                   .append(MAX_ATTR).append(snapshot.getMax()).append(END_LSTR);
+        snapMetrics.append(helpName)
+                   .append(MEAN_ATTR).append(snapshot.getMean()).append(END_LSTR);
+        snapMetrics.append(helpName)
+                   .append(STDDEV_ATTR).append(snapshot.getStdDev()).append(END_LSTR);
+        snapMetrics.append(helpName)
+                   .append(P50_ATTR).append(snapshot.getMedian()).append(END_LSTR);
+        snapMetrics.append(helpName)
+                   .append(P75_ATTR).append(snapshot.get75thPercentile()).append(END_LSTR);
+        snapMetrics.append(helpName)
+                   .append(P95_ATTR).append(snapshot.get95thPercentile()).append(END_LSTR);
+        snapMetrics.append(helpName)
+                   .append(P98_ATTR).append(snapshot.get98thPercentile()).append(END_LSTR);
+        snapMetrics.append(helpName)
+                   .append(P99_ATTR).append(snapshot.get99thPercentile()).append(END_LSTR);
+        snapMetrics.append(helpName)
+                   .append(P999_ATTR).append(snapshot.get999thPercentile()).append(END_LSTR);
+        return snapMetrics.toString();
+    }
+}

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/metrics/ServerReporter.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/metrics/ServerReporter.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mkyong.metrics;
+
+import com.codahale.metrics.*;
+import com.google.common.collect.ImmutableSortedMap;
+
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class ServerReporter extends ScheduledReporter {
+
+    private static volatile ServerReporter instance = null;
+
+    private SortedMap<String, Gauge<?>> gauges;
+    private SortedMap<String, Counter> counters;
+    private SortedMap<String, Histogram> histograms;
+    private SortedMap<String, Meter> meters;
+    private SortedMap<String, Timer> timers;
+
+    public static synchronized ServerReporter instance(
+            MetricRegistry registry) {
+        if (instance == null) {
+            synchronized (ServerReporter.class) {
+                if (instance == null) {
+                    instance = new ServerReporter(registry);
+                }
+            }
+        }
+        return instance;
+    }
+
+    public static ServerReporter instance() {
+//        E.checkNotNull(instance, "Must instantiate ServerReporter before get");
+        return instance;
+    }
+
+    private ServerReporter(MetricRegistry registry) {
+        this(registry, SECONDS, MILLISECONDS, MetricFilter.ALL);
+    }
+
+    private ServerReporter(MetricRegistry registry, TimeUnit rateUnit,
+                           TimeUnit durationUnit, MetricFilter filter) {
+        super(registry, "server-reporter", filter, rateUnit, durationUnit);
+        this.gauges = ImmutableSortedMap.of();
+        this.counters = ImmutableSortedMap.of();
+        this.histograms = ImmutableSortedMap.of();
+        this.meters = ImmutableSortedMap.of();
+        this.timers = ImmutableSortedMap.of();
+    }
+
+    public Map<String, Timer> timers() {
+        return Collections.unmodifiableMap(this.timers);
+    }
+
+    public Map<String, Gauge<?>> gauges() {
+        return Collections.unmodifiableMap(this.gauges);
+    }
+
+    public Map<String, Counter> counters() {
+        return Collections.unmodifiableMap(this.counters);
+    }
+
+    public Map<String, Histogram> histograms() {
+        return Collections.unmodifiableMap(this.histograms);
+    }
+
+    public Map<String, Meter> meters() {
+        return Collections.unmodifiableMap(this.meters);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public void report(SortedMap<String, Gauge> gauges,
+                       SortedMap<String, Counter> counters,
+                       SortedMap<String, Histogram> histograms,
+                       SortedMap<String, Meter> meters,
+                       SortedMap<String, Timer> timers) {
+        this.gauges = (SortedMap) gauges;
+        this.counters = counters;
+        this.histograms = histograms;
+        this.meters = meters;
+        this.timers = timers;
+    }
+}

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/metrics/SlowQueryLog.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/metrics/SlowQueryLog.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mkyong.metrics;
+
+public class SlowQueryLog {
+
+    public String rawQuery;
+
+    public String method;
+
+    public String path;
+
+    public long executeTime;
+
+    public long startTime;
+
+    public long thresholdTime;
+
+    public SlowQueryLog(String rawQuery, String method, String path,
+                        long executeTime, long startTime, long thresholdTime) {
+        this.rawQuery = rawQuery;
+        this.method = method;
+        this.path = path;
+        this.executeTime = executeTime;
+        this.startTime = startTime;
+        this.thresholdTime = thresholdTime;
+    }
+
+    @Override
+    public String toString() {
+        return "SlowQueryLog{executeTime=" + executeTime +
+               ", startTime=" + startTime +
+               ", rawQuery='" + rawQuery + '\'' +
+               ", method='" + method + '\'' +
+               ", threshold=" + thresholdTime +
+               ", path='" + path + '\'' +
+               '}';
+    }
+}

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/metrics/SystemMetrics.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/metrics/SystemMetrics.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mkyong.metrics;
+
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.lang.management.*;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SystemMetrics {
+
+    private static final long MB = 1024 * 1044;
+
+    public Map<String, Map<String, Object>> metrics() {
+        Map<String, Map<String, Object>> metrics = new LinkedHashMap<>();
+        metrics.put("basic", this.getBasicMetrics());
+        metrics.put("heap", this.getHeapMetrics());
+        metrics.put("nonheap", this.getNonHeapMetrics());
+        metrics.put("thread", this.getThreadMetrics());
+        metrics.put("class_loading", this.getClassLoadingMetrics());
+        metrics.put("garbage_collector", this.getGarbageCollectionMetrics());
+        return metrics;
+    }
+
+    private Map<String, Object> getBasicMetrics() {
+        Map<String, Object> metrics = new LinkedHashMap<>();
+        Runtime runtime = Runtime.getRuntime();
+        // Heap allocated memory (measured in bytes)
+        long total = runtime.totalMemory();
+        // Heap free memory
+        long free = runtime.freeMemory();
+        long used = total - free;
+
+        metrics.put("mem", (total + totalNonHeapMemory()) / MB);
+        metrics.put("mem_total", total / MB);
+        metrics.put("mem_used", used / MB);
+        metrics.put("mem_free", free / MB);
+        metrics.put("mem_unit", "MB");
+        metrics.put("processors", runtime.availableProcessors());
+        metrics.put("uptime", ManagementFactory.getRuntimeMXBean().getUptime());
+        metrics.put("systemload_average",
+                    ManagementFactory.getOperatingSystemMXBean()
+                                     .getSystemLoadAverage());
+        return metrics;
+    }
+
+    private static long totalNonHeapMemory() {
+        try {
+            return ManagementFactory.getMemoryMXBean()
+                                    .getNonHeapMemoryUsage()
+                                    .getCommitted();
+        } catch (Throwable ignored) {
+            return 0;
+        }
+    }
+
+    private Map<String, Object> getHeapMetrics() {
+        Map<String, Object> metrics = new LinkedHashMap<>();
+        MemoryUsage memoryUsage = ManagementFactory.getMemoryMXBean()
+                                                   .getHeapMemoryUsage();
+        metrics.put("committed", memoryUsage.getCommitted() / MB);
+        metrics.put("init", memoryUsage.getInit() / MB);
+        metrics.put("used", memoryUsage.getUsed() / MB);
+        metrics.put("max", memoryUsage.getMax() / MB);
+        return metrics;
+    }
+
+    private Map<String, Object> getNonHeapMetrics() {
+        Map<String, Object> metrics = new LinkedHashMap<>();
+        MemoryUsage memoryUsage = ManagementFactory.getMemoryMXBean()
+                                                   .getNonHeapMemoryUsage();
+        metrics.put("committed", memoryUsage.getCommitted() / MB);
+        metrics.put("init", memoryUsage.getInit() / MB);
+        metrics.put("used", memoryUsage.getUsed() / MB);
+        metrics.put("max", memoryUsage.getMax() / MB);
+        return metrics;
+    }
+
+    private Map<String, Object> getThreadMetrics() {
+        Map<String, Object> metrics = new LinkedHashMap<>();
+        ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
+        metrics.put("peak", threadMxBean.getPeakThreadCount());
+        metrics.put("daemon", threadMxBean.getDaemonThreadCount());
+        metrics.put("total_started", threadMxBean.getTotalStartedThreadCount());
+        metrics.put("count", threadMxBean.getThreadCount());
+        return metrics;
+    }
+
+    private Map<String, Object> getClassLoadingMetrics() {
+        Map<String, Object> metrics = new LinkedHashMap<>();
+        ClassLoadingMXBean classLoadingMxBean = ManagementFactory
+                .getClassLoadingMXBean();
+        metrics.put("count", classLoadingMxBean.getLoadedClassCount());
+        metrics.put("loaded", classLoadingMxBean.getTotalLoadedClassCount());
+        metrics.put("unloaded", classLoadingMxBean.getUnloadedClassCount());
+        return metrics;
+    }
+
+    private Map<String, Object> getGarbageCollectionMetrics() {
+        Map<String, Object> metrics = new LinkedHashMap<>();
+        List<GarbageCollectorMXBean> gcMxBeans = ManagementFactory
+                .getGarbageCollectorMXBeans();
+        for (GarbageCollectorMXBean gcMxBean : gcMxBeans) {
+            String name = formatName(gcMxBean.getName());
+            metrics.put(name + "_count", gcMxBean.getCollectionCount());
+            metrics.put(name + "_time", gcMxBean.getCollectionTime());
+        }
+        metrics.put("time_unit", "ms");
+        return metrics;
+    }
+
+    private static String formatName(String name) {
+        return StringUtils.replace(name, " ", "_").toLowerCase();
+    }
+}

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/resource/MetricsAPI.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/resource/MetricsAPI.java
@@ -1,0 +1,299 @@
+package com.mkyong.resource;
+
+import com.codahale.metrics.*;
+import com.codahale.metrics.annotation.Timed;
+import com.mkyong.metrics.MetricsKeys;
+import com.mkyong.metrics.MetricsUtil;
+import com.mkyong.metrics.ServerReporter;
+import com.mkyong.service.MessageService;
+import com.mkyong.util.JsonUtil;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.tinkerpop.gremlin.server.util.MetricManager;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.mkyong.metrics.MetricsUtil.*;
+
+@Path("metrics")
+public class MetricsAPI {
+    public static final String CHARSET = "UTF-8";
+    public static final String TEXT_PLAIN = MediaType.TEXT_PLAIN;
+    public static final String APPLICATION_JSON = MediaType.APPLICATION_JSON;
+    public static final String APPLICATION_JSON_WITH_CHARSET =
+            APPLICATION_JSON + ";charset=" + CHARSET;
+    public static final String APPLICATION_TEXT_WITH_CHARSET =
+            MediaType.TEXT_PLAIN + ";charset=" + CHARSET;
+
+    private static final String JSON_STR = "json";
+
+
+
+    // DI via HK2
+    @Inject
+    private MessageService messageService;
+
+    @GET
+    @Timed
+    @Produces(APPLICATION_TEXT_WITH_CHARSET)
+    public String all(@QueryParam("type") String type) throws Exception {
+        if (type != null && type.equals(JSON_STR)) {
+            return baseMetricAll();
+        } else {
+            return baseMetricPrometheusAll();
+        }
+    }
+
+    @GET
+    @Path("statistics")
+    @Timed
+    @Produces(APPLICATION_TEXT_WITH_CHARSET)
+    public String statistics(@QueryParam("type") String type) {
+        Map<String, Map<String, Object>> metricMap = statistics();
+
+        if (type != null && type.equals(JSON_STR)) {
+            try {
+                return JsonUtil.toJson(metricMap);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        return statisticsProm(metricMap);
+    }
+
+    public String baseMetricAll() throws Exception {
+        ServerReporter reporter = ServerReporter.instance();
+        Map<String, Map<String, ? extends Metric>> result = new LinkedHashMap<>();
+        result.put("gauges", reporter.gauges());
+        result.put("counters", reporter.counters());
+        result.put("histograms", reporter.histograms());
+        result.put("meters", reporter.meters());
+        result.put("timers", reporter.timers());
+        return JsonUtil.toJson(result);
+
+    }
+
+    private String baseMetricPrometheusAll() {
+        StringBuilder promMetric = new StringBuilder();
+        ServerReporter reporter = ServerReporter.instance();
+        String helpName = PROM_HELP_NAME;
+        // build version info
+        promMetric.append(STR_HELP)
+                .append(helpName).append(END_LSTR);
+        promMetric.append(STR_TYPE)
+                .append(helpName)
+                .append(SPACE_STR + UNTYPED + END_LSTR);
+        promMetric.append(helpName)
+                .append(VERSION_STR)
+                .append("ApiVersion.VERSION.toString()").append("\",}")
+                .append(SPACE_STR + "1.0" + END_LSTR);
+
+        // build gauges metric info
+        for (String key : reporter.gauges().keySet()) {
+            final Gauge<?> gauge
+                    = reporter.gauges().get(key);
+            if (gauge != null) {
+                helpName = replaceDotDashInKey(key);
+                promMetric.append(STR_HELP)
+                        .append(helpName).append(END_LSTR);
+                promMetric.append(STR_TYPE)
+                        .append(helpName).append(SPACE_STR + GAUGE_TYPE + END_LSTR);
+                promMetric.append(helpName)
+                        .append(SPACE_STR + gauge.getValue() + END_LSTR);
+            }
+        }
+
+        // build histograms metric info
+        for (String histogramkey : reporter.histograms().keySet()) {
+            final Histogram histogram = reporter.histograms().get(histogramkey);
+            if (histogram != null) {
+                helpName = replaceDotDashInKey(histogramkey);
+                promMetric.append(STR_HELP)
+                        .append(helpName).append(END_LSTR);
+                promMetric.append(STR_TYPE)
+                        .append(helpName)
+                        .append(SPACE_STR + HISTOGRAM_TYPE + END_LSTR);
+
+                promMetric.append(helpName)
+                        .append(COUNT_ATTR)
+                        .append(histogram.getCount() + END_LSTR);
+                promMetric.append(
+                        exportSnapshot(helpName, histogram.getSnapshot()));
+            }
+        }
+
+        // build meters metric info
+        for (String meterkey : reporter.meters().keySet()) {
+            final Meter metric = reporter.meters().get(meterkey);
+            if (metric != null) {
+                helpName = replaceDotDashInKey(meterkey);
+                promMetric.append(STR_HELP)
+                        .append(helpName).append(END_LSTR);
+                promMetric.append(STR_TYPE)
+                        .append(helpName)
+                        .append(SPACE_STR + HISTOGRAM_TYPE + END_LSTR);
+
+                promMetric.append(helpName)
+                        .append(COUNT_ATTR)
+                        .append(metric.getCount() + END_LSTR);
+                promMetric.append(helpName)
+                        .append(MEAN_RATE_ATRR)
+                        .append(metric.getMeanRate() + END_LSTR);
+                promMetric.append(helpName)
+                        .append(ONE_MIN_RATE_ATRR)
+                        .append(metric.getOneMinuteRate() + END_LSTR);
+                promMetric.append(helpName)
+                        .append(FIVE_MIN_RATE_ATRR)
+                        .append(metric.getFiveMinuteRate() + END_LSTR);
+                promMetric.append(helpName)
+                        .append(FIFT_MIN_RATE_ATRR)
+                        .append(metric.getFifteenMinuteRate() + END_LSTR);
+            }
+        }
+
+        // build timer metric info
+        for (String timerkey : reporter.timers().keySet()) {
+            final com.codahale.metrics.Timer timer = reporter.timers()
+                    .get(timerkey);
+            if (timer != null) {
+                helpName = replaceDotDashInKey(timerkey);
+                promMetric.append(STR_HELP)
+                        .append(helpName).append(END_LSTR);
+                promMetric.append(STR_TYPE)
+                        .append(helpName)
+                        .append(SPACE_STR + HISTOGRAM_TYPE + END_LSTR);
+
+                promMetric.append(helpName)
+                        .append(COUNT_ATTR)
+                        .append(timer.getCount() + END_LSTR);
+                promMetric.append(helpName)
+                        .append(ONE_MIN_RATE_ATRR)
+                        .append(timer.getOneMinuteRate() + END_LSTR);
+                promMetric.append(helpName)
+                        .append(FIVE_MIN_RATE_ATRR)
+                        .append(timer.getFiveMinuteRate() + END_LSTR);
+                promMetric.append(helpName)
+                        .append(FIFT_MIN_RATE_ATRR)
+                        .append(timer.getFifteenMinuteRate() + END_LSTR);
+                promMetric.append(
+                        exportSnapshot(helpName, timer.getSnapshot()));
+            }
+        }
+
+        // build Counter metric info
+        for (String counterkey : reporter.counters().keySet()) {
+            final Counter counter = reporter.counters().get(counterkey);
+            if (counter != null) {
+                helpName = replaceDotDashInKey(counterkey);
+                promMetric.append(STR_HELP)
+                        .append(helpName).append(END_LSTR);
+                promMetric.append(STR_TYPE)
+                        .append(helpName)
+                        .append(SPACE_STR + HISTOGRAM_TYPE + END_LSTR);
+
+                promMetric.append(helpName)
+                        .append(COUNT_ATTR)
+                        .append(counter.getCount() + END_LSTR);
+            }
+        }
+
+        MetricsUtil.writePrometheusFormat(promMetric, MetricManager.INSTANCE.getRegistry());
+
+        return promMetric.toString();
+    }
+
+
+    private String statisticsProm(Map<String, Map<String, Object>> metricMap) {
+        StringBuilder promMetric = new StringBuilder();
+
+        // build version info
+        promMetric.append(STR_HELP)
+                .append(PROM_HELP_NAME).append(END_LSTR);
+        promMetric.append(STR_TYPE)
+                .append(PROM_HELP_NAME)
+                .append(SPACE_STR + UNTYPED + END_LSTR);
+        promMetric.append(PROM_HELP_NAME)
+                .append(VERSION_STR)
+                .append("ApiVersion.VERSION.toString()").append("\",}")
+                .append(SPACE_STR + "1.0" + END_LSTR);
+
+        for (String methodKey : metricMap.keySet()) {
+            String metricName = replaceSlashInKey(methodKey);
+            promMetric.append(STR_HELP)
+                    .append(metricName).append(END_LSTR);
+            promMetric.append(STR_TYPE)
+                    .append(metricName).append(SPACE_STR + GAUGE_TYPE + END_LSTR);
+            Map<String, Object> itemMetricMap = metricMap.get(methodKey);
+            for (String labelName : itemMetricMap.keySet()) {
+                promMetric.append(metricName).append(LEFT_NAME_STR).append(labelName)
+                        .append(RIGHT_NAME_STR).append(itemMetricMap.get(labelName))
+                        .append(END_LSTR);
+            }
+        }
+        return promMetric.toString();
+    }
+
+    private Map<String, Map<String, Object>> statistics() {
+        Map<String, Map<String, Object>> metricsMap = new HashMap<>();
+        ServerReporter reporter = ServerReporter.instance();
+        for (Map.Entry<String, Histogram> entry : reporter.histograms().entrySet()) {
+            // entryKey = path/method/responseTimeHistogram
+            String entryKey = entry.getKey();
+            String[] split = entryKey.split("/");
+            String lastWord = split[split.length - 1];
+            if (!lastWord.equals(METRICS_PATH_RESPONSE_TIME_HISTOGRAM)) {
+                // original metrics dont report
+                continue;
+            }
+            // metricsName = path/method
+            String metricsName =
+                    entryKey.substring(0, entryKey.length() - lastWord.length() - 1);
+
+            Counter totalCounter = reporter.counters().get(
+                    joinWithSlash(metricsName, METRICS_PATH_TOTAL_COUNTER));
+            Counter failedCounter = reporter.counters().get(
+                    joinWithSlash(metricsName, METRICS_PATH_FAILED_COUNTER));
+            Counter successCounter = reporter.counters().get(
+                    joinWithSlash(metricsName, METRICS_PATH_SUCCESS_COUNTER));
+
+            Histogram histogram = entry.getValue();
+            Map<String, Object> entryMetricsMap = new HashMap<>();
+            entryMetricsMap.put(MetricsKeys.MAX_RESPONSE_TIME.name(),
+                    histogram.getSnapshot().getMax());
+            entryMetricsMap.put(MetricsKeys.MEAN_RESPONSE_TIME.name(),
+                    histogram.getSnapshot().getMean());
+
+            entryMetricsMap.put(MetricsKeys.TOTAL_REQUEST.name(),
+                    totalCounter.getCount());
+
+            if (failedCounter == null) {
+                entryMetricsMap.put(MetricsKeys.FAILED_REQUEST.name(), 0);
+            } else {
+                entryMetricsMap.put(MetricsKeys.FAILED_REQUEST.name(),
+                        failedCounter.getCount());
+            }
+
+            if (successCounter == null) {
+                entryMetricsMap.put(MetricsKeys.SUCCESS_REQUEST.name(), 0);
+            } else {
+                entryMetricsMap.put(MetricsKeys.SUCCESS_REQUEST.name(),
+                        successCounter.getCount());
+            }
+
+            metricsMap.put(metricsName, entryMetricsMap);
+
+        }
+        return metricsMap;
+    }
+
+    private String joinWithSlash(String path1, String path2) {
+        return String.join("/", path1, path2);
+    }
+
+}

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/resource/MyResource.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/resource/MyResource.java
@@ -1,5 +1,6 @@
 package com.mkyong.resource;
 
+import com.codahale.metrics.annotation.Timed;
 import com.mkyong.service.MessageService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -8,7 +9,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-@Path("/hello")
+@Path("hello/{graph}/vertices")
 public class MyResource {
 
     // DI via HK2
@@ -16,6 +17,7 @@ public class MyResource {
     private MessageService messageService;
 
     // output text
+    @Timed(name = "single-create")
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
@@ -23,7 +25,7 @@ public class MyResource {
     }
 
     // output text with argument
-    @Path("/{name}")
+    @Path("{name}")
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello(@PathParam("name") String name) {
@@ -31,7 +33,7 @@ public class MyResource {
     }
 
     // for dependency injection
-    @Path("/hk2")
+    @Path("hk2")
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String helloHK2() {

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/resource/PathParamAPI.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/resource/PathParamAPI.java
@@ -1,0 +1,25 @@
+package com.mkyong.resource;
+
+
+import com.mkyong.service.MessageService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("graphs/graph/vertices")
+public class PathParamAPI {
+
+    // DI via HK2
+    @Inject
+    private MessageService messageService;
+
+    // output text
+    @Path("{id}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String PathParam() {
+        return "Jersey hello Path Param!";
+    }
+}

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/util/ApiVersion.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/util/ApiVersion.java
@@ -1,0 +1,114 @@
+package com.mkyong.util;
+
+//import org.apache.hugegraph.util.VersionUtil;
+//import org.apache.hugegraph.util.VersionUtil.Version;
+
+public final class ApiVersion {
+
+    /*
+     * API Version change log
+     * <p>
+     * version 0.2:
+     * [0.2] HugeGraph-527: First add the version to the hugegraph module
+     * [0.3] HugeGraph-525: Add versions check of components and api
+     * [0.4] HugeGraph-162: Add schema builder to separate client and inner interface.
+     * [0.5] HugeGraph-498: Support three kinds of id strategy
+     * <p>
+     * version 0.3:
+     * <p>
+     * [0.6] HugeGraph-614: Add update api of VL/EL to support append and eliminate action
+     * [0.7] HugeGraph-245: Add nullable-props for vertex label and edge label
+     * [0.8] HugeGraph-396: Continue to improve variables implementation
+     * [0.9] HugeGraph-894: Add vertex/edge update api to add property and remove property
+     * [0.10] HugeGraph-919: Add condition query for vertex/edge list API
+     * <p>
+     * version 0.4:
+     * [0.11] HugeGraph-938: Remove useless index-names field in VL/EL API
+     * [0.12] HugeGraph-589: Add schema id for all schema elements
+     * [0.13] HugeGraph-956: Support customize string/number id strategy
+     * <p>
+     * version 0.5:
+     * [0.14] HugeGraph-1085: Add enable_label_index to VL/EL
+     * [0.15] HugeGraph-1105: Support paging for large numbers of records
+     * [0.16] HugeGraph-944: Support rest shortest path, k-out, k-neighbor
+     * [0.17] HugeGraph-944: Support rest shortest path, k-out, k-neighbor
+     * [0.18] HugeGraph-81: Change argument "checkVertex" to "check_vertex"
+     * <p>
+     * version 0.6:
+     * [0.19] HugeGraph-1195: Support eliminate userdata on schema
+     * [0.20] HugeGraph-1210: Add paths api to find paths between two nodes
+     * [0.21] HugeGraph-1197: Expose scan api for hugegraph-spark
+     * [0.22] HugeGraph-1162: Support authentication and permission control
+     * [0.23] HugeGraph-1176: Support degree and capacity for traverse api
+     * [0.24] HugeGraph-1261: Add param offset for vertex/edge list API
+     * [0.25] HugeGraph-1272: Support set/clear restore status of graph
+     * [0.26] HugeGraph-1273: Add some monitoring counters to integrate with
+     *        gremlin's monitoring framework
+     * [0.27] HugeGraph-889: Use asynchronous mechanism to do schema deletion
+     * <p>
+     * version 0.8:
+     * [0.28] Issue-153: Add task-cancel API
+     * [0.29] Issue-39: Add rays and rings RESTful API
+     * [0.30] Issue-32: Change index create API to return indexLabel and task id
+     * [0.31] Issue-182: Support restore graph in restoring and merging mode
+     * <p>
+     * version 0.9:
+     * [0.32] Issue-250: Keep depth and degree consistent for traverser api
+     * [0.33] Issue-305: Implement customized paths and crosspoints RESTful API
+     * [0.34] Issue-307: Let VertexAPI use simplified property serializer
+     * [0.35] Issue-287: Support pagination when do index query
+     * [0.36] Issue-360: Support paging for scan api
+     * [0.37] Issue-391: Add skip_super_node for the shortest path
+     * [0.38] Issue-274: Add personal-rank and neighbor-rank RESTful API
+     * <p>
+     * version 0.10:
+     * [0.39] Issue-522: Add profile RESTful API
+     * [0.40] Issue-523: Add source_in_ring args for rings RESTful API
+     * [0.41] Issue-493: Support batch updating properties by multiple strategy
+     * [0.42] Issue-176: Let gremlin error response consistent with RESTful's
+     * [0.43] Issue-270 & 398: support shard-index and vertex + sort-key prefix,
+     *        and split range to rangeInt, rangeFloat, rangeLong and rangeDouble
+     * [0.44] Issue-633: Support unique index
+     * [0.45] Issue-673: Add 'OVERRIDE' update strategy
+     * [0.46] Issue-618 & 694: Support UUID id type
+     * [0.47] Issue-691: Support aggregate property
+     * [0.48] Issue-686: Support get schema by names
+     * <p>
+     * version 0.11:
+     * [0.49] Issue-670: Support fusiform similarity API
+     * [0.50] Issue-746: Support userdata for index label
+     * [0.51] Issue-929: Support 5 TP RESTful API
+     * [0.52] Issue-781: Support range query for rest api like P.gt(18)
+     * [0.53] Issue-985: Add grant permission API
+     * [0.54] Issue-295: Support ttl for vertex and edge
+     * [0.55] Issue-994: Support results count for kneighbor/kout/rings
+     * [0.56] Issue-800: Show schema status in schema API
+     * [0.57] Issue-1105: Allow not rebuild index when create index label
+     * [0.58] Issue-1173: Supports customized kout/kneighbor,
+     *        multi-node-shortest-path, jaccard-similar and template-paths
+     * [0.59] Issue-1333: Support graph read mode for olap property
+     * [0.60] Issue-1392: Support create and resume snapshot
+     * [0.61] Issue-1433: Unify naming of degree for oltp algorithms
+     * [0.62] Issue-1378: Add compact api for rocksdb/cassandra/hbase backend
+     * [0.63] Issue-1500: Add user-login RESTful API
+     * [0.64] Issue-1504: Add auth-project RESTful API
+     * [0.65] Issue-1506: Support olap property key
+     * [0.66] Issue-1567: Support get schema RESTful API
+     * [0.67] Issue-1065: Support dynamically add/remove graph
+     * [0.68] Issue-1763: Support adamic-adar & resource-allocation API
+     * [0.69] Issue-1748: Support Cypher query RESTful API
+     * [0.70] PR-2242: Add edge-existence RESTful API
+     * [0.71] PR-2286: Support Arthas API & Metric API prometheus format
+     */
+
+    /**
+     * The second parameter of Version.of() is for IDE running without JAR
+     * Note: Also update the version number in hugegraph-server/hugegraph-api/pom.xml
+     */
+//    public static final Version VERSION = Version.of(ApiVersion.class, "0.71");
+
+//    public static void check() {
+//        // Check the version of hugegraph-core. Do first check from version 0.3
+//        VersionUtil.check(CoreVersion.VERSION, "1.0", "1.6", CoreVersion.NAME);
+//    }
+}

--- a/jersey/jersey-hello-world/src/main/java/com/mkyong/util/JsonUtil.java
+++ b/jersey/jersey-hello-world/src/main/java/com/mkyong/util/JsonUtil.java
@@ -1,0 +1,145 @@
+package com.mkyong.util;
+
+import java.io.IOException;
+import java.util.Date;
+
+
+import org.apache.tinkerpop.shaded.jackson.core.JsonGenerator;
+import org.apache.tinkerpop.shaded.jackson.core.JsonProcessingException;
+import org.apache.tinkerpop.shaded.jackson.core.type.TypeReference;
+import org.apache.tinkerpop.shaded.jackson.databind.Module;
+import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
+import org.apache.tinkerpop.shaded.jackson.databind.ObjectReader;
+import org.apache.tinkerpop.shaded.jackson.databind.SerializerProvider;
+import org.apache.tinkerpop.shaded.jackson.databind.module.SimpleModule;
+import org.apache.tinkerpop.shaded.jackson.databind.ser.std.StdSerializer;
+
+import com.google.common.collect.ImmutableSet;
+
+public final class JsonUtil {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ImmutableSet<String> SPECIAL_FLOATS;
+
+    static {
+        SimpleModule module = new SimpleModule();
+        SPECIAL_FLOATS = ImmutableSet.of("-Infinity", "Infinity", "NaN");
+
+        module.addSerializer(RawJson.class, new RawJsonSerializer());
+
+//        HugeGraphSONModule.registerCommonSerializers(module);
+//        HugeGraphSONModule.registerIdSerializers(module);
+//        HugeGraphSONModule.registerSchemaSerializers(module);
+//        HugeGraphSONModule.registerGraphSerializers(module);
+
+        MAPPER.registerModule(module);
+    }
+
+    public static void registerModule(Module module) {
+        MAPPER.registerModule(module);
+    }
+
+    public static String toJson(Object object) throws Exception {
+        return MAPPER.writeValueAsString(object);
+    }
+
+    public static <T> T fromJson(String json, Class<T> clazz) throws Exception {
+//        E.checkState(json != null,
+//                "Json value can't be null for '%s'",
+//                clazz.getSimpleName());
+        try {
+            return MAPPER.readValue(json, clazz);
+        } catch (IOException e) {
+            //throw new HugeException("Can't read json: %s", e, e.getMessage());
+            throw new Exception("error");
+        }
+    }
+
+    public static <T> T fromJson(String json, TypeReference<?> typeRef) throws Exception {
+//        E.checkState(json != null,
+//                "Json value can't be null for '%s'",
+//                typeRef.getType());
+        try {
+            ObjectReader reader = MAPPER.readerFor(typeRef);
+            return reader.readValue(json);
+        } catch (IOException e) {
+            //throw new HugeException("Can't read json: %s", e, e.getMessage());
+            throw new Exception("error");
+        }
+    }
+
+    /**
+     * Number collection will be parsed to Double Collection via fromJson,
+     * this method used to cast element in collection to original number type
+     *
+     * @param object original number
+     * @param clazz  target type
+     * @return target number
+     */
+    public static Object castNumber(Object object, Class<?> clazz) {
+        if (object instanceof Number) {
+            Number number = (Number) object;
+            if (clazz == Byte.class) {
+                object = number.byteValue();
+            } else if (clazz == Integer.class) {
+                object = number.intValue();
+            } else if (clazz == Long.class) {
+                object = number.longValue();
+            } else if (clazz == Float.class) {
+                object = number.floatValue();
+            } else if (clazz == Double.class) {
+                assert object instanceof Double : object;
+            } else {
+                assert clazz == Date.class : clazz;
+            }
+        }
+        return object;
+    }
+
+    public static <V> boolean isInfinityOrNaN(V value) {
+        return value instanceof String && SPECIAL_FLOATS.contains(value);
+    }
+
+    public static Object asJson(Object value) {
+        RawJson rj = null;
+        try {
+            rj = new RawJson(toJson(value));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return rj;
+    }
+
+    public static Object asJson(String value) {
+        return new RawJson(value);
+    }
+
+    private static class RawJson {
+
+        private final String value;
+
+        public RawJson(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return this.value;
+        }
+    }
+
+    private static class RawJsonSerializer extends StdSerializer<RawJson> {
+
+        private static final long serialVersionUID = 3240301861031054251L;
+
+        public RawJsonSerializer() {
+            super(RawJson.class);
+        }
+
+        @Override
+        public void serialize(RawJson json, JsonGenerator generator,
+                              SerializerProvider provider) throws IOException {
+            generator.writeRawValue(json.value());
+        }
+    }
+}
+


### PR DESCRIPTION
基于jersy 框架实现如下功能：

```
1. 实现Rest Ful 接口
2. 实现埋点，采集监控，调用次数等
3. 收集指标，进行ETL 输出PromThos 格式
4. 实现Filter 拦截器，统计Path 调用次数 以及 慢查询统计
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced metrics and monitoring functionalities to the application.
  - Added system metrics to monitor memory usage, thread counts, class loading, and garbage collection.
  - Included new endpoints for retrieving metrics in JSON and Prometheus formats.

- **Enhancements**
  - Updated resource paths and added timing annotations for better performance tracking.
  - Enhanced logging and filtering of access requests in the RESTful service.

- **Documentation**
  - Added a section in Chinese to the README detailing the implementation of tracking development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->